### PR TITLE
Extend Mapillary API wrapper

### DIFF
--- a/311-data/mapillarywrapper/mapillarywrapper/client/client.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/client/client.py
@@ -30,11 +30,15 @@ class MapClient:
                 f"client_id={self.CLIENT_ID}&sort_by=key"
             )
         complete_url = self.BASE_DOMAIN + params
+        print("Requesting data from Mapillary API")
+        print(complete_url)
         response = requests.get(complete_url)
         if response.status_code != 200:
             return error_response(response)
         url_links = [response.links["first"]["url"]]
         current_link = response.links
+        print("Pages found (with up to {} results per page):\n-".format(perpage), end="\r")
+        i=0
         while "next" in current_link:
             next_url = current_link["next"]["url"]
             url_links.append(next_url)
@@ -42,10 +46,16 @@ class MapClient:
             if new_response.status_code != 200:
                 return error_response(response)
             current_link = new_response.links
+            i +=1
+            print(i, end="\r")
+        print(i + 1)
         transform_list = []
         temp_transform = usecase.Properties()
+        print("Pages of results loaded:\n-", end="\r")
         for i, v in enumerate(url_links):
             temp_response = requests.get(v)
             temp_json = temp_response.json()
             transform_list += temp_transform.transform_json_(temp_json)
+            print(i, end="\r")
+        print(i + 1)
         return transform_list

--- a/311-data/mapillarywrapper/mapillarywrapper/client/client.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/client/client.py
@@ -8,25 +8,29 @@ def error_response(response):
     """
     print(response)
 
-
 class MapClient:
     def __init__(self, YOUR_CLIENT_ID: str) -> None:
         self.CLIENT_ID = YOUR_CLIENT_ID
         self.BASE_DOMAIN = "https://a.mapillary.com/v3/map_features"
 
     def trafficinfo(
-        self, lowerbbox: list, upperbbox: list, perpage: int = 1, value=None
+        self,
+        lowerbbox: list,
+        upperbbox: list,
+        perpage: int = 1,
+        layer: str = "trafficsigns",
+        value=None
     ):
         bbox_list = [*lowerbbox[::-1], *upperbbox[::-1]]
         bbox = ",".join([repr(point) for point in bbox_list])
         if value is not None:
             params = (
-                f"?layers=trafficsigns&bbox={bbox}&value={value}&per_page={perpage}&"
+                f"?layers={layer}&bbox={bbox}&value={value}&per_page={perpage}&"
                 f"client_id={self.CLIENT_ID}&sort_by=key"
             )
         else:
             params = (
-                f"?layers=trafficsigns&bbox={bbox}&per_page={perpage}&"
+                f"?layers={layer}&bbox={bbox}&per_page={perpage}&"
                 f"client_id={self.CLIENT_ID}&sort_by=key"
             )
         complete_url = self.BASE_DOMAIN + params

--- a/311-data/mapillarywrapper/mapillarywrapper/client/client.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/client/client.py
@@ -32,7 +32,7 @@ class MapClient:
         complete_url = self.BASE_DOMAIN + params
         print("Requesting data from Mapillary API")
         print(complete_url)
-        response = requests.get(complete_url)
+        response = requests.get(complete_url, timeout=300)
         if response.status_code != 200:
             return error_response(response)
         url_links = [response.links["first"]["url"]]
@@ -42,7 +42,7 @@ class MapClient:
         while "next" in current_link:
             next_url = current_link["next"]["url"]
             url_links.append(next_url)
-            new_response = requests.get(next_url)
+            new_response = requests.get(next_url, timeout=300)
             if new_response.status_code != 200:
                 return error_response(response)
             current_link = new_response.links
@@ -53,7 +53,7 @@ class MapClient:
         temp_transform = usecase.Properties()
         print("Pages of results loaded:\n-", end="\r")
         for i, v in enumerate(url_links):
-            temp_response = requests.get(v)
+            temp_response = requests.get(v, timeout=300)
             temp_json = temp_response.json()
             transform_list += temp_transform.transform_json_(temp_json)
             print(i, end="\r")

--- a/311-data/mapillarywrapper/mapillarywrapper/domain/trafficsign.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/domain/trafficsign.py
@@ -10,7 +10,8 @@ class TrafficSign:
         layer: str,
         value: str,
         image_keys: str,
-        coordinates: list,
+        latitude: float,
+        longitude: float,
         geometry_type: str,
     ) -> None:
         self.accuracy = accuracy
@@ -22,7 +23,8 @@ class TrafficSign:
         self.layer = layer
         self.value = value
         self.image_keys = image_keys
-        self.coordinates = coordinates
+        self.latitude = latitude
+        self.longitude = longitude
         self.geometry_type = geometry_type
 
     @classmethod
@@ -38,7 +40,8 @@ class TrafficSign:
             layer=adict["layer"],
             value=adict["value"],
             image_keys=adict["image_keys"],
-            coordinates=adict["coordinates"],
+            latitude=adict["latitude"],
+            longitude=adict["longitude"],
             geometry_type=adict["geometry_type"],
         )
 
@@ -54,6 +57,7 @@ class TrafficSign:
             "layer": self.layer,
             "value": self.value,
             "image_keys": self.image_keys,
-            "coordinates": self.coordinates,
+            "latitude": self.latitude,
+            "longitude": self.longitude,
             "geometry_type": self.geometry_type,
         }

--- a/311-data/mapillarywrapper/mapillarywrapper/domain/trafficsign.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/domain/trafficsign.py
@@ -9,6 +9,7 @@ class TrafficSign:
         key: str,
         layer: str,
         value: str,
+        image_keys: str,
         coordinates: list,
         geometry_type: str,
     ) -> None:
@@ -20,6 +21,7 @@ class TrafficSign:
         self.key = key
         self.layer = layer
         self.value = value
+        self.image_keys = image_keys
         self.coordinates = coordinates
         self.geometry_type = geometry_type
 
@@ -35,6 +37,7 @@ class TrafficSign:
             key=adict["key"],
             layer=adict["layer"],
             value=adict["value"],
+            image_keys=adict["image_keys"],
             coordinates=adict["coordinates"],
             geometry_type=adict["geometry_type"],
         )
@@ -50,6 +53,7 @@ class TrafficSign:
             "key": self.key,
             "layer": self.layer,
             "value": self.value,
+            "image_keys": self.image_keys,
             "coordinates": self.coordinates,
             "geometry_type": self.geometry_type,
         }

--- a/311-data/mapillarywrapper/mapillarywrapper/usecase/usecase.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/usecase/usecase.py
@@ -18,6 +18,7 @@ class Properties:
                 key = sub_json_[collection]["properties"]["key"]
                 layer = sub_json_[collection]["properties"]["layer"]
                 value = sub_json_[collection]["properties"]["value"]
+                image_keys = [detection["image_key"] for detection in sub_json_[collection]["properties"]["detections"]]
                 coordinates = sub_json_[collection]["geometry"]["coordinates"]
                 geometry_type = sub_json_[collection]["geometry"]["type"]
                 traffic_sign = ts.TrafficSign(
@@ -29,6 +30,7 @@ class Properties:
                     key,
                     layer,
                     value,
+                    image_keys,
                     coordinates,
                     geometry_type,
                 )

--- a/311-data/mapillarywrapper/mapillarywrapper/usecase/usecase.py
+++ b/311-data/mapillarywrapper/mapillarywrapper/usecase/usecase.py
@@ -19,7 +19,8 @@ class Properties:
                 layer = sub_json_[collection]["properties"]["layer"]
                 value = sub_json_[collection]["properties"]["value"]
                 image_keys = [detection["image_key"] for detection in sub_json_[collection]["properties"]["detections"]]
-                coordinates = sub_json_[collection]["geometry"]["coordinates"]
+                latitude = sub_json_[collection]["geometry"]["coordinates"][1]
+                longitude = sub_json_[collection]["geometry"]["coordinates"][0]
                 geometry_type = sub_json_[collection]["geometry"]["type"]
                 traffic_sign = ts.TrafficSign(
                     accuracy,
@@ -31,7 +32,8 @@ class Properties:
                     layer,
                     value,
                     image_keys,
-                    coordinates,
+                    latitude,
+                    longitude,
                     geometry_type,
                 )
                 new_json_list.append(traffic_sign.to_dict())


### PR DESCRIPTION
These are new features for the python wrapper for Mapillary's API to allow it to:

- Make requests of other layers of Mapillary data beyond traffic signs

- Store photo image IDs associated with each item on map

- Parse Mapillary's latitude/longitude string format

- Give feedback while downloading data and timeout after 5 minutes, to prevent downloads from failing silently