### PR TITLE
re-refactor normalize address

### DIFF
--- a/LAANE/transformations/insert_address.py
+++ b/LAANE/transformations/insert_address.py
@@ -24,13 +24,15 @@ def get_address_id(session, row) -> int:
             Address.zipcode == row['Zipcode'],
         ).one_or_none()
     )
+    # Need to wrap datatype.
+    # Data was not being insered in some case do to diferent datatypes.
     if address is None:
         address = Address(
-            address1=row['Address1'],
-            address2=row['Address2'],
-            city=row['City'],
-            state=row['State'],
-            zipcode=row['Zipcode'],
+            address1=str(row['Address1']),
+            address2=str(row['Address2']),
+            city=str(row['City']),
+            state=str(row['State']),
+            zipcode=int(row['Zipcode']),
         )
         session.add(address)
         session.commit()

--- a/LAANE/transformations/normalize_address.py
+++ b/LAANE/transformations/normalize_address.py
@@ -22,5 +22,5 @@ def normalize_address_wrapper(address: str) -> dict:
             'city': '',
             'state': '',
             'postal_code': 00000,
-        }
+        },
     )

--- a/LAANE/transformations/normalize_address.py
+++ b/LAANE/transformations/normalize_address.py
@@ -14,13 +14,13 @@ def normalize_address_wrapper(address: str) -> dict:
     :param address: an address to break into multiple address fields.
     """
     # TODO Would like to have type hint return a dataclass since it's mixed data
-    # default return should be empty strings and postal should be 00000.
+    # default returns None because that's how the library handles it.
     return safe(normalize_address_record)(address).value_or(
         {
             'address_line_1': address,
-            'address_line_2': '',
-            'city': '',
-            'state': '',
-            'postal_code': 00000,
+            'address_line_2': None,
+            'city': None,
+            'state': None,
+            'postal_code': None,
         },
     )


### PR DESCRIPTION
normalize address wrapper returns none as default again because that's how the library handle it, shouldn't return two different options.